### PR TITLE
Maken OpenApi types in PHP compatible with phpstan

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -365,6 +365,13 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
             }
             return "array<string," + getTypeDeclaration(inner) + ">";
         } else if (StringUtils.isNotBlank(p.get$ref())) { // model
+            Schema ref = ModelUtils.unaliasSchema(this.openAPI, p);
+
+            // The reference points to something that is not a model
+            if (ref != p) {
+                return getTypeDeclaration(ref);
+            }
+
             String type = super.getTypeDeclaration(p);
             return (!languageSpecificPrimitives.contains(type))
                     ? "\\" + modelPackage + "\\" + type : type;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -356,14 +356,14 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
                 LOGGER.warn(ap.getName() + "(array property) does not have a proper inner type defined.Default to string");
                 inner = new StringSchema().description("TODO default missing array inner type to string");
             }
-            return getTypeDeclaration(inner) + "[]";
+            return "array<int," + getTypeDeclaration(inner) + ">";
         } else if (ModelUtils.isMapSchema(p)) {
             Schema inner = ModelUtils.getAdditionalProperties(p);
             if (inner == null) {
                 LOGGER.warn(p.getName() + "(map property) does not have a proper inner type defined. Default to string");
                 inner = new StringSchema().description("TODO default missing map inner type to string");
             }
-            return getSchemaType(p) + "[string," + getTypeDeclaration(inner) + "]";
+            return "array<string," + getTypeDeclaration(inner) + ">";
         } else if (StringUtils.isNotBlank(p.get$ref())) { // model
             String type = super.getTypeDeclaration(p);
             return (!languageSpecificPrimitives.contains(type))
@@ -373,7 +373,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
             for (Schema one: ((ComposedSchema) p).getOneOf()) {
                 inners.add(getTypeDeclaration(one));
             }
-            return "oneOf[" + String.join(", ", inners) + "]";
+            return String.join("|", inners);
         }
         return super.getTypeDeclaration(p);
     }

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -251,8 +251,15 @@ class ObjectSerializer
           return $deserialized[0]['value'];
         } elseif (substr($class, 0, strlen('array<string,')) === 'array<string,') { // for associative array e.g. map[string,int]
             $data = is_string($data) ? json_decode($data) : $data;
-            settype($data, 'array');
-            return $data;
+            $subClass = substr($class, strlen('array<string,'), -1);
+            $values = [];
+            if (!is_object($data) && !is_array($data)) {
+                throw new \InvalidArgumentException('expected map');
+            }
+            foreach ($data as $key => $value) {
+                $values[$key] = self::deserialize($value, $subClass, null);
+            }
+            return $values;
         } elseif (substr($class, 0, strlen('array<int,')) === 'array<int,') {
             $data = is_string($data) ? json_decode($data) : $data;
             $subClass = substr($class, strlen('array<int,'), -1);

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -229,29 +229,13 @@ class ObjectSerializer
     {
         if (null === $data) {
             return null;
-        } elseif (substr($class, 0, 4) === 'map[') { // for associative array e.g. map[string,int]
-            $data = is_string($data) ? json_decode($data) : $data;
-            settype($data, 'array');
-            return $data;
-        } elseif (strcasecmp(substr($class, -2), '[]') === 0) {
-            $data = is_string($data) ? json_decode($data) : $data;
-            $subClass = substr($class, 0, -2);
-            $values = [];
-            if (!is_array($data)) {
-                throw new \InvalidArgumentException('expected array');
-            }
-            foreach ($data as $key => $value) {
-                $values[] = self::deserialize($value, $subClass, null);
-            }
-            return $values;
-        } elseif (substr($class, 0, strlen('oneOf[')) === 'oneOf[') {
-          $inner = substr($class, strlen('oneOf['), -1);
-          $options = explode(',', $inner);
+        } elseif (preg_match_all('/\G((?:[^|<>]++|<(?1)(?:\|(?1))*>)++)(?:$|\|)/', $class, $matches) > 1) {
+          $options = $matches[1];
           $deserialized = [];
           $errors = [];
           foreach ($options as $option) {
             try {
-              $deserialized[] = ['option' => trim($option), 'value' => self::deserialize($data, trim($option), $httpHeaders)];
+              $deserialized[] = ['option' => $option, 'value' => self::deserialize($data, $option, $httpHeaders)];
             } catch (\InvalidArgumentException $e) {
               $errors[] = $e->getMessage();
             }
@@ -265,6 +249,21 @@ class ObjectSerializer
             throw new \InvalidArgumentException('no values matched oneOf:\n    '. implode('\n    ', $errors));
           }
           return $deserialized[0]['value'];
+        } elseif (substr($class, 0, strlen('array<string,')) === 'array<string,') { // for associative array e.g. map[string,int]
+            $data = is_string($data) ? json_decode($data) : $data;
+            settype($data, 'array');
+            return $data;
+        } elseif (substr($class, 0, strlen('array<int,')) === 'array<int,') {
+            $data = is_string($data) ? json_decode($data) : $data;
+            $subClass = substr($class, strlen('array<int,'), -1);
+            $values = [];
+            if (!is_array($data)) {
+                throw new \InvalidArgumentException('expected array');
+            }
+            foreach ($data as $key => $value) {
+                $values[] = self::deserialize($value, $subClass, null);
+            }
+            return $values;
         } elseif ($class === 'object') {
             settype($data, 'array');
             return $data;
@@ -327,7 +326,7 @@ class ObjectSerializer
             }
             $instance = new $class();
             if (!empty($instance::oneOf())) {
-                return self::deserialize($original_data, "oneOf[". implode(', ', $instance->oneOf())  ."]", $httpHeaders);
+                return self::deserialize($original_data, implode('|', $instance->oneOf()), $httpHeaders);
             }
             $reverseAttributes = array_flip($instance::attributeMap());
             $data = is_array($data) ? (object)$data : $data;

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -170,14 +170,14 @@ use {{invokerPackage}}\ObjectSerializer;
             {{/-first}}
             {{#dataType}}
                 {{^isWildcard}}case {{code}}:{{/isWildcard}}{{#isWildcard}}default:{{/isWildcard}}
-                    if ('{{dataType}}' === '\SplFileObject') {
+                    if ('{{{dataType}}}' === '\SplFileObject') {
                         $content = $responseBody; //stream goes to serializer
                     } else {
                         $content = $responseBody->getContents();
                     }
 
                     return [
-                        ObjectSerializer::deserialize($content, '{{dataType}}', []),
+                        ObjectSerializer::deserialize($content, '{{{dataType}}}', []),
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
@@ -187,7 +187,7 @@ use {{invokerPackage}}\ObjectSerializer;
             {{/-last}}
         {{/responses}}
 
-            $returnType = '{{returnType}}';
+            $returnType = '{{{returnType}}}';
             $responseBody = $response->getBody();
             if ($returnType === '\SplFileObject') {
                 $content = $responseBody; //stream goes to serializer
@@ -213,7 +213,7 @@ use {{invokerPackage}}\ObjectSerializer;
                 {{^isWildcard}}case {{code}}:{{/isWildcard}}{{#isWildcard}}default:{{/isWildcard}}
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
-                        '{{dataType}}',
+                        '{{{dataType}}}',
                         $e->getResponseHeaders()
                     );
                     $e->setResponseObject($data);
@@ -277,7 +277,7 @@ use {{invokerPackage}}\ObjectSerializer;
      */
     public function {{operationId}}AsyncWithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
     {
-        $returnType = '{{returnType}}';
+        $returnType = '{{{returnType}}}';
         $request = $this->{{operationId}}Request({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}});
 
         return $this->client

--- a/modules/openapi-generator/src/main/resources/php/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -194,7 +194,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
     }
 
     public static function oneOf() {
-        return [{{#oneOfTypes}}'{{.}}'{{^-last}}, {{/-last}}{{/oneOfTypes}}];
+        return [{{#oneOfTypes}}'{{{.}}}'{{^-last}}, {{/-last}}{{/oneOfTypes}}];
     }
 
     /**
@@ -219,20 +219,19 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
     }
 
     public static function mapType(string $type): bool {
-        return substr($type, 0, strlen('map[')) === 'map[';
+        return substr($type, 0, strlen('array<string,')) === 'array<string,';
     }
 
     public static function oneOfTypes(string $type): array {
-        if (substr($type, 0, strlen('oneOf[')) === 'oneOf[') {
-            $inner = substr($type, strlen('oneOf['), -1);
-            return array_map('trim', explode(',', $inner));
+        if (preg_match_all('/\G((?:[^|<>]++|<(?1)(?:\|(?1))*>)++)(?:$|\|)/', $type, $matches) > 1) {
+            return $matches[1];
         }
         return [];
     }
 
     private static function arrayType(string $type): ?string {
-        if (substr($type, -2) === '[]') {
-           return substr($type, 0, -2);
+        if (substr($type, 0, strlen('array<int,')) === 'array<int,') {
+            return substr($type, strlen('array<int,'), -1);
         }
         return null;
     }
@@ -323,14 +322,14 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
     }
 
     public static function errorsAs(string $dataType, $data): array {
+        if (self::oneOfTypes($dataType)) {
+          return self::errorsOneOf(self::oneOfTypes($dataType), $data);
+        }
         if (self::arrayType($dataType)) {
             return self::errorsArray(self::arrayType($dataType), $data);
         }
         if (self::mapType($dataType)) {
             return self::errorsMap($data);
-        }
-        if (self::oneOfTypes($dataType)) {
-            return self::errorsOneOf(self::oneOfTypes($dataType), $data);
         }
         if (self::modelInterfaceType($dataType)) {
             return self::errorsModelInterface(self::modelInterfaceType($dataType), $data);
@@ -340,7 +339,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
 
     public static function dataType(): string {
         if (count(self::oneOf()) > 0) {
-            return 'oneOf[' . implode(', ', self::oneOf()) . ']';
+            return implode('|', self::oneOf());
         }
         return '\\' . get_class();
     }
@@ -372,7 +371,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
     /**
      * Gets {{name}}
      *
-     * @return {{dataType}}{{^required}}|null{{/required}}
+     * @return {{{dataType}}}{{^required}}|null{{/required}}
      */
     public function {{getter}}()
     {
@@ -382,7 +381,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
     /**
      * Sets {{name}}
      *
-     * @param {{dataType}}{{^required}}|null{{/required}} ${{name}}{{#description}} {{{description}}}{{/description}}{{^description}} {{{name}}}{{/description}}
+     * @param {{{dataType}}}{{^required}}|null{{/required}} ${{name}}{{#description}} {{{description}}}{{/description}}{{^description}} {{{name}}}{{/description}}
      *
      * @return $this
      */
@@ -422,7 +421,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         }
         {{/required}}
         if (${{name}} !== null) {
-            $errors = self::errorsAs('{{dataType}}', ${{name}});
+            $errors = self::errorsAs('{{{dataType}}}', ${{name}});
             if (count($errors) > 0) {
                 return  $errors;
             }

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -239,6 +239,18 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         return null;
     }
 
+    private static function errorsMap(string $type, $data): array {
+        if (!is_array($data)) {
+            return [new ValidationError('value is not an array')];
+        }
+        $errors = [];
+        foreach($data as $ix => $element) {
+            $element_errors = array_map(function($e) use ($ix) { return $e->path($ix); }, self::errorsAs($type, $element));
+            $errors = array_merge($errors, $element_errors);
+        }
+        return $errors;
+    }
+
     private static function errorsOneOf(array $options, $data): array {
         $errors = [];
         $matches = [];
@@ -262,6 +274,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
     private static function errorsArray(string $type, $data): array {
         if (!is_array($data)) {
             return [new ValidationError('value is not an array')];
+        }
+        if ($data !== [] && \array_keys($data) !== \range(0, \count($data) - 1)) {
+            return [new ValidationError('value is not an indexed array')];
         }
         $errors = [];
         foreach($data as $ix => $element) {
@@ -325,7 +340,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
             return self::errorsArray(self::arrayType($dataType), $data);
         }
         if (self::mapType($dataType)) {
-            return self::errorsArray(self::mapType($dataType), $data);
+            return self::errorsMap(self::mapType($dataType), $data);
         }
         if (self::modelInterfaceType($dataType)) {
             return self::errorsModelInterface(self::modelInterfaceType($dataType), $data);

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -218,8 +218,11 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         return $invalidProperties;
     }
 
-    public static function mapType(string $type): bool {
-        return substr($type, 0, strlen('array<string,')) === 'array<string,';
+    public static function mapType(string $type): ?string {
+        if (substr($type, 0, strlen('array<string,')) === 'array<string,') {
+            return substr($type, strlen('array<string,'), -1);
+        }
+        return null;
     }
 
     public static function oneOfTypes(string $type): array {
@@ -234,13 +237,6 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
             return substr($type, strlen('array<int,'), -1);
         }
         return null;
-    }
-
-    private static function errorsMap($data): array {
-        if (!is_array($data)) {
-            return [new ValidationError('value is not an array')];
-        }
-        return [];
     }
 
     private static function errorsOneOf(array $options, $data): array {
@@ -323,13 +319,13 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
 
     public static function errorsAs(string $dataType, $data): array {
         if (self::oneOfTypes($dataType)) {
-          return self::errorsOneOf(self::oneOfTypes($dataType), $data);
+            return self::errorsOneOf(self::oneOfTypes($dataType), $data);
         }
         if (self::arrayType($dataType)) {
             return self::errorsArray(self::arrayType($dataType), $data);
         }
         if (self::mapType($dataType)) {
-            return self::errorsMap($data);
+            return self::errorsArray(self::mapType($dataType), $data);
         }
         if (self::modelInterfaceType($dataType)) {
             return self::errorsModelInterface(self::modelInterfaceType($dataType), $data);


### PR DESCRIPTION
**Reasoning and background behind this PR**

- Currently the OpenApi generator generates `@return` and `@param` annotations like `oneOf` or `map[]`, which are not recognized by phpstan
- There are also some inconsistencies and deficiencies with validation and usage of maps
- The deserialization also handles multiple levels of arrays and maps incorrectly

**Changes and additions in this PR**

- Changes the generator to use `TYPE|TYPE` in case of "one of" instead of `oneOf[TYPE, TYPE]`
- Changes the generator to use `array<int,TYPE>` for arrays instead of `TYPE[]`
- Changes the generator to use `array<string,TYPE>` for maps instead of `map[string,TYPE]`
- Fixes generation of types when there are multiple levels of arrays or maps, so that you get `array<string,array<string,string>>` instead of `map[string,\OpenApi\Goya\Model\map]`
- Fixes parsing of multiple levels of types
- Adds validation to maps so that the type of values in map is actually validated
- Adds validation to array to ensure that the keys are correct
- Changed all levels of maps being treated as arrays instead of treating them as objects after one level deep

**Other notes or foreseeable issues**

- The PR on v1 that contains the api generated with this PR: https://github.com/smartlyio/smartly-v1/pull/21084