### PR TITLE
differentiate between sequential arrays and associative

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -267,6 +267,9 @@ class ObjectSerializer
             if (!is_array($data)) {
                 throw new \InvalidArgumentException('expected array');
             }
+            if($data !== array_values($data)) {
+                throw new \InvalidArgumentException('expected sequential array');
+            }
             foreach ($data as $key => $value) {
                 $values[] = self::deserialize($value, $subClass, null);
             }


### PR DESCRIPTION
distinguishing between oneof array/object does not work as array matcher accepts any, ie also non-numeric, keys for fields.

