### PR TITLE
SENATORS-126 | FIX for oneof with string and object type

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -297,7 +297,7 @@ class ObjectSerializer
                 return null;
             }
         } elseif (in_array($class, [{{&primitives}}], true)) {
-            if (is_array($data) && $class !== 'object') {
+            if ((is_array($data) || is_object($data)) && $class !== 'object') {
                 throw new \InvalidArgumentException('invalid cast of array value to ' . $class);
             }
             try {

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -297,12 +297,12 @@ class ObjectSerializer
                 return null;
             }
         } elseif (in_array($class, [{{&primitives}}], true)) {
-            if ((is_array($data) || is_object($data)) && $class !== 'object') {
+            if (is_array($data) && $class !== 'object') {
                 throw new \InvalidArgumentException('invalid cast of array value to ' . $class);
             }
             try {
                 settype($data, $class);
-            } catch (\ErrorException $e) {
+            } catch (\Error $e) {
                 throw new \InvalidArgumentException('invalid cast: ' . $e->getMessage());
             }
             return $data;

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -238,6 +238,9 @@ class ObjectSerializer
           $deserialized = [];
           $errors = [];
           foreach ($options as $option) {
+            if ($option !== 'string' && in_array('string', $options) && is_string($data)) {
+                continue;
+            }
             try {
               $deserialized[] = ['option' => $option, 'value' => self::deserialize($data, $option, $httpHeaders)];
             } catch (\InvalidArgumentException $e) {


### PR DESCRIPTION
Having this schema fails with error `too many matching options for oneOf` because we have here oneOf between string and object, but our PHP code also accepts String for Object type to make `json_decode` during value decoding. This means that we pass a string under oneOf and it matches with both oneOf values, that's why it throws an error.

```yaml
    macro:
      type: object
      additionalProperties: false
      properties:
        macro:
          type: string
      required:
        - macro

    MacroString:
      oneOf:
        - $ref: '#/components/schemas/nullableString'
        - $ref: '#/components/schemas/macro'
    ad:
     ....
     name:
          $ref: '#/components/schemas/MacroString'
```

This fix is checking if we have `oneOf` with `string` and the actual given data is a string, then we are keeping only a string option.