### PR TITLE
Check for string before method_exists

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -62,7 +62,7 @@ class ObjectSerializer
                     }
                     $openAPIType = ($data::openAPITypes()[$property] ?? null) ?: null;
                     if ($value !== null
-                        && !in_array($openAPIType, [{{&primitives}}], true)
+                        && !in_array($openAPIType, [{{&primitives}}, null], true)
                         && method_exists($openAPIType, 'getAllowableEnumValues')
                         && !in_array($value, $openAPIType::getAllowableEnumValues(), true)) {
                         $imploded = implode("', '", $openAPIType::getAllowableEnumValues());


### PR DESCRIPTION
When running unit tests in PHP8, the tests are complaining that `method_exists()` is called with `null` value. Apparently the type checks in the function have gotten more strict. Thus, we need to change the template a bit to check for string type before calling the function.

The v1 PR with the generated clients : https://github.com/smartlyio/smartly-v1/pull/23037